### PR TITLE
Add seller rating system

### DIFF
--- a/models.py
+++ b/models.py
@@ -36,6 +36,8 @@ class User(BaseModel):
     address = CharField(null=True)          # <== ОБЯЗАТЕЛЬНО
     bio = TextField(null=True)
     avatar_url = CharField(null=True)
+    rating_total = FloatField(default=0)
+    rating_count = IntegerField(default=0)
 
 
 

--- a/queries.py
+++ b/queries.py
@@ -13,6 +13,15 @@ def get_user_by_wallet(wallet_address):
         return model_to_dict(user)
     except peewee.DoesNotExist:
         return False
+
+
+def get_user(username):
+    """Return user dict by username or wallet address."""
+    try:
+        user = User.get(User.wallet_address == username)
+        return model_to_dict(user)
+    except peewee.DoesNotExist:
+        return False
     
 def user_to_dict(user):
     return {
@@ -21,7 +30,9 @@ def user_to_dict(user):
         "full_name": user.full_name or "",
         "address": user.address or "",
         "bio": user.bio or "",
-        "avatar_url": user.avatar_url or ""
+        "avatar_url": user.avatar_url or "",
+        "rating_total": user.rating_total,
+        "rating_count": user.rating_count
     }
 
 

--- a/templates/my_profile.html
+++ b/templates/my_profile.html
@@ -34,6 +34,7 @@
                 <i class="fas fa-map-marker-alt"></i> {{ user.address }}
             </p>
             <p class="mt-2">{{ user.bio }}</p>
+            <p>Рейтинг: {{ (user.rating_total / user.rating_count)|round(1) if user.rating_count else 0 }} ({{ user.rating_count }})</p>
             </div>
 
             <!-- Кнопка редактировать -->

--- a/templates/rate_seller.html
+++ b/templates/rate_seller.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="section">
+  <div class="container">
+    <h1 class="title">Оцените продавца {{ seller.full_name }}</h1>
+    <form method="post">
+      <div class="field">
+        <label class="label">Рейтинг (1-5)</label>
+        <div class="control">
+          <input class="input" type="number" name="rating" min="1" max="5" required>
+        </div>
+      </div>
+      <div class="field">
+        <button class="button is-primary" type="submit">Отправить</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/templates/user_page.html
+++ b/templates/user_page.html
@@ -30,6 +30,9 @@
                             ellipsis_user.username }}</h1>
                         <h2 class="subtitle mb-3">{{ ellipsis_user.bio }}</h2>
                         <p class="has-text-weight-light">{{ ellipsis_user.address }}</p>
+                        <p class="has-text-weight-light">Рейтинг: {{
+                            (ellipsis_user.rating_total / ellipsis_user.rating_count)|round(1) if ellipsis_user.rating_count else 0
+                        }} ({{ ellipsis_user.rating_count }})</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add rating fields to `User`
- update login session data with rating info
- record and display seller rating after a deal
- create page to rate a seller
- show rating on user pages
- implement helper function `get_user`

## Testing
- `python -m py_compile models.py main.py queries.py`

------
https://chatgpt.com/codex/tasks/task_e_683f73a1b8648329b215490b8cbb82fa