### PR TITLE
Add basic logging

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -1,6 +1,9 @@
 __winc_id__ = "d7b474e9b3a54d23bca54879a4f1855b"
 __human_name__ = "ellipsis Webshop"
 
+import logging
+
+logger = logging.getLogger("application")
 import peewee
 from peewee import fn
 from flask import flash
@@ -51,6 +54,12 @@ def edit_user(user_id, name, address, bio, avatar_url):
             user.avatar_url = avatar_url
 
         user.save()
+        logger.info(
+            "User profile updated: id=%s name=%s address=%s",
+            user.user_id,
+            user.full_name,
+            user.address,
+        )
         return user_to_dict(user)
     except peewee.PeeweeException:
         return False
@@ -64,7 +73,12 @@ def add_product_to_catalog(product_info):
 
         product = Product.create(title=product_info["title"], description=product_info['description'],
                                  price_in_cents=product_info['price_in_cents'], qty=product_info['qty'], vendor=user)
-        # product.save()
+        logger.info(
+            "Product added: id=%s title=%s vendor=%s",
+            product.prod_id,
+            product.title,
+            user.user_id,
+        )
         return product.prod_id
     except peewee.PeeweeException:
         return False


### PR DESCRIPTION
## Summary
- add configuration for logging and log chat events, status changes
- log profile updates and new products
- stop Flask request logs from polluting `application.log`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684174c54a9c83299cdb11ee45fb9579